### PR TITLE
Add runner for METI LNG weekly inventory

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -1,5 +1,8 @@
-import requests
+import sys
+from datetime import datetime
 from pathlib import Path
+
+import requests
 
 
 class meti:
@@ -32,3 +35,15 @@ class meti:
         file_path.write_bytes(response.content)
 
         return str(file_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python meti_scraper.py YYYY/MM/DD")
+        sys.exit(1)
+
+    date_str = sys.argv[1]
+    dt = datetime.strptime(date_str, "%Y/%m/%d")
+
+    scraper = meti()
+    scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+import sys
+
+from meti_scraper import meti
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD')
+        sys.exit(1)
+
+    date_str = sys.argv[1]
+    dt = datetime.strptime(date_str, '%Y/%m/%d')
+
+    scraper = meti()
+    scraper.lng_weekly_inventory(date=dt.strftime('%Y%m%d'))


### PR DESCRIPTION
## Summary
- allow running `lng_weekly_inventory` directly from `meti_scraper.py`
- provide `run_meti_lng_weekly_inventory.py` helper for date-based execution
- add `requests` dependency

## Testing
- `pip install -r requirements.txt`
- `python run_meti_lng_weekly_inventory.py 2025/08/06` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e4d0cdb1c8320ab38a641e5c732f9