### PR TITLE
Compute last Wednesday automatically

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -1,5 +1,4 @@
-import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import requests
@@ -38,12 +37,9 @@ class meti:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python meti_scraper.py YYYY/MM/DD")
-        sys.exit(1)
-
-    date_str = sys.argv[1]
-    dt = datetime.strptime(date_str, "%Y/%m/%d")
+    today = datetime.today()
+    offset = (today.weekday() - 2) % 7 or 7
+    last_wednesday = today - timedelta(days=offset)
 
     scraper = meti()
-    scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
+    scraper.lng_weekly_inventory(date=last_wednesday.strftime("%Y%m%d"))

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -1,12 +1,16 @@
-from datetime import datetime, timedelta
+from datetime import datetime
+import sys
 
 from meti_scraper import meti
 
 
 if __name__ == '__main__':
-    today = datetime.today()
-    offset = (today.weekday() - 2) % 7 or 7
-    last_wednesday = today - timedelta(days=offset)
+    if len(sys.argv) != 2:
+        print('Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD')
+        sys.exit(1)
+
+    date_str = sys.argv[1]
+    dt = datetime.strptime(date_str, '%Y/%m/%d')
 
     scraper = meti()
-    scraper.lng_weekly_inventory(date=last_wednesday.strftime('%Y%m%d'))
+    scraper.lng_weekly_inventory(date=dt.strftime('%Y%m%d'))

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -1,16 +1,12 @@
-from datetime import datetime
-import sys
+from datetime import datetime, timedelta
 
 from meti_scraper import meti
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print('Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD')
-        sys.exit(1)
-
-    date_str = sys.argv[1]
-    dt = datetime.strptime(date_str, '%Y/%m/%d')
+    today = datetime.today()
+    offset = (today.weekday() - 2) % 7 or 7
+    last_wednesday = today - timedelta(days=offset)
 
     scraper = meti()
-    scraper.lng_weekly_inventory(date=dt.strftime('%Y%m%d'))
+    scraper.lng_weekly_inventory(date=last_wednesday.strftime('%Y%m%d'))


### PR DESCRIPTION
## Summary
- Calculate previous Wednesday automatically and use it to download METI LNG weekly stock PDF
- Remove command-line argument requirement in entry scripts

## Testing
- `python run_meti_lng_weekly_inventory.py` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f31fac88320aa5fac1d21e2e5de