### PR TITLE
Add robust retry logic for METI LNG stock download

### DIFF
--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -4,13 +4,18 @@ import sys
 from meti_scraper import meti
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print('Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD')
+        print("Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD")
         sys.exit(1)
 
     date_str = sys.argv[1]
-    dt = datetime.strptime(date_str, '%Y/%m/%d')
+    dt = datetime.strptime(date_str, "%Y/%m/%d")
 
     scraper = meti()
-    scraper.lng_weekly_inventory(date=dt.strftime('%Y%m%d'))
+    try:
+        scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)
+


### PR DESCRIPTION
## Summary
- add retry, timeout, and user-agent for METI LNG PDF request
- handle download errors in command line entry point

## Testing
- `python run_meti_lng_weekly_inventory.py 2024/01/01` *(fails: Failed to download METI LNG stock PDF)*
- `python meti_scraper.py` *(fails: Failed to download METI LNG stock PDF)*

------
https://chatgpt.com/codex/tasks/task_e_688e51bb2aa48320977559ae1406790b