### PR TITLE
Add PDF to Markdown conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+pdfplumber
+pytesseract

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -14,7 +14,8 @@ if __name__ == "__main__":
 
     scraper = meti()
     try:
-        scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
+        pdf_path = scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
+        scraper.pdf_to_markdown(pdf_path)
     except RuntimeError as err:
         print(err)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add pdfplumber and pytesseract dependencies
- implement pdf_to_markdown utility with OCR fallback
- convert downloaded PDF to Markdown in scripts

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
from meti_scraper import meti
m=meti()
print(m.pdf_to_markdown('pdf/lng/dummy.pdf'))
PY`
- `python -m py_compile meti_scraper.py run_meti_lng_weekly_inventory.py`


------
https://chatgpt.com/codex/tasks/task_e_688e53391efc83208b972bf20332d35b