### PR TITLE
Add table-preserving PDF-to-Markdown conversion

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -58,12 +58,33 @@ class meti:
 
         return str(file_path)
 
-    def pdf_to_markdown(self, pdf_path: str) -> str:
-        """Convert a PDF to a Markdown file with extracted text.
+    def _extract_text(self, page) -> str:
+        """Extract text from a PDF page, falling back to OCR if needed."""
+        text = page.extract_text()
+        if text:
+            return text
+        try:
+            image = page.to_image(resolution=300).original
+            return pytesseract.image_to_string(image)
+        except Exception:
+            return ""
 
-        The function first tries to extract embedded text from the PDF.
-        If no text is found on a page, it falls back to OCR using
-        ``pytesseract`` for better accuracy.
+    def _table_to_markdown(self, table) -> str:
+        """Convert a table (list of lists) to a Markdown string."""
+        if not table:
+            return ""
+        header = [cell or "" for cell in table[0]]
+        md_lines = ["| " + " | ".join(header) + " |"]
+        md_lines.append("| " + " | ".join("---" for _ in header) + " |")
+        for row in table[1:]:
+            md_lines.append("| " + " | ".join(cell or "" for cell in row) + " |")
+        return "\n".join(md_lines)
+
+    def pdf_to_markdown(self, pdf_path: str) -> str:
+        """Convert a PDF to Markdown, preserving tables when possible.
+
+        This method extracts text and tables from each page. If a page
+        lacks embedded text, OCR is used as a fallback.
 
         Parameters
         ----------
@@ -79,18 +100,32 @@ class meti:
         pdf_file = Path(pdf_path)
         md_file = pdf_file.with_suffix(".md")
 
+        parts = []
+        with pdfplumber.open(pdf_file) as pdf:
+            for page in pdf.pages:
+                text = self._extract_text(page)
+                if text:
+                    parts.append(text)
+                for table in page.extract_tables() or []:
+                    md_table = self._table_to_markdown(table)
+                    if md_table:
+                        parts.append(md_table)
+
+        md_file.write_text("\n\n".join(parts), encoding="utf-8")
+        return str(md_file)
+
+    def pdf_to_markdown_plain(self, pdf_path: str) -> str:
+        """Convert a PDF to Markdown with text extraction only."""
+
+        pdf_file = Path(pdf_path)
+        md_file = pdf_file.with_suffix(".md")
+
         text_parts = []
         with pdfplumber.open(pdf_file) as pdf:
             for page in pdf.pages:
-                text = page.extract_text()
+                text = self._extract_text(page)
                 if text:
                     text_parts.append(text)
-                else:
-                    try:
-                        image = page.to_image(resolution=300).original
-                        text_parts.append(pytesseract.image_to_string(image))
-                    except Exception:
-                        continue
 
         md_file.write_text("\n\n".join(text_parts), encoding="utf-8")
         return str(md_file)


### PR DESCRIPTION
## Summary
- add `_extract_text` and `_table_to_markdown` helpers
- add new `pdf_to_markdown` that preserves tables
- keep prior behavior as `pdf_to_markdown_plain`

## Testing
- `python -m py_compile meti_scraper.py run_meti_lng_weekly_inventory.py`
- `python run_meti_lng_weekly_inventory.py 2024/06/05` *(fails: Failed to download METI LNG stock PDF)*

------
https://chatgpt.com/codex/tasks/task_e_688e553b0474832093d43de917ba5e54