### PR TITLE
Add CSV export for PDF tables

### DIFF
--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
     try:
         pdf_path = scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
         scraper.pdf_to_markdown(pdf_path)
+        scraper.pdf_tables_to_csv(pdf_path)
     except RuntimeError as err:
         print(err)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Add `pdf_tables_to_csv` to extract tables from a PDF and store them as CSV with consistent filenames
- Invoke the new CSV export during example usage and command-line script

## Testing
- `python run_meti_lng_weekly_inventory.py 2025/07/30` *(failed: Failed to download METI LNG stock PDF)*
- `python - <<'PY'
from meti_scraper import meti
scraper = meti()
paths = scraper.pdf_tables_to_csv('pdf/lng/stock/denryoku_LNG_stock_20250730.pdf')
print(paths)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688e5bf78af483209aa195cf9f97f075