### PR TITLE
Use Wednesday date algorithm for METI scraper

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -210,10 +210,16 @@ class meti:
 
 if __name__ == "__main__":
     today = datetime.today()
-    offset = (today.weekday() - 2) % 7 or 7
-    last_wednesday = today - timedelta(days=offset)
+    weekday = today.weekday()  # Monday = 0, Sunday = 6
+
+    if weekday >= 2:
+        monday = today - timedelta(days=weekday)
+        target_wed = monday + timedelta(days=2)
+    else:
+        monday = today - timedelta(days=weekday + 7)
+        target_wed = monday + timedelta(days=2)
 
     scraper = meti()
-    pdf_path = scraper.lng_weekly_inventory(date=last_wednesday.strftime("%Y%m%d"))
+    pdf_path = scraper.lng_weekly_inventory(date=target_wed.strftime("%Y%m%d"))
     scraper.pdf_to_markdown(pdf_path)
     scraper.pdf_tables_to_csv(pdf_path)

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -1,20 +1,23 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import sys
 
 from meti_scraper import meti
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python run_meti_lng_weekly_inventory.py YYYY/MM/DD")
-        sys.exit(1)
+    today = datetime.today()
+    weekday = today.weekday()  # Monday = 0, Sunday = 6
 
-    date_str = sys.argv[1]
-    dt = datetime.strptime(date_str, "%Y/%m/%d")
+    if weekday >= 2:
+        monday = today - timedelta(days=weekday)
+        target_wed = monday + timedelta(days=2)
+    else:
+        monday = today - timedelta(days=weekday + 7)
+        target_wed = monday + timedelta(days=2)
 
     scraper = meti()
     try:
-        pdf_path = scraper.lng_weekly_inventory(date=dt.strftime("%Y%m%d"))
+        pdf_path = scraper.lng_weekly_inventory(date=target_wed.strftime("%Y%m%d"))
         scraper.pdf_to_markdown(pdf_path)
         scraper.pdf_tables_to_csv(pdf_path)
     except RuntimeError as err:


### PR DESCRIPTION
## Summary
- use current-week-or-previous-week Wednesday logic in `meti_scraper` main
- automate `run_meti_lng_weekly_inventory.py` with same Wednesday calculation

## Testing
- `python -m py_compile meti_scraper.py run_meti_lng_weekly_inventory.py`
- `python run_meti_lng_weekly_inventory.py` *(fails: Failed to download METI LNG stock PDF)*
- `python meti_scraper.py` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688e669916c88320905338f94a40571f