### PR TITLE
Export production sheet to CSV and normalize filenames

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pdfplumber
 pytesseract
+openpyxl


### PR DESCRIPTION
## Summary
- sanitize industrial production filenames by replacing the '・' character with underscores
- export the '生産' sheet from the industrial production workbook to a separate CSV
- add openpyxl dependency for Excel processing

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile meti_scraper.py run_meti_lng_weekly_inventory.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7aaaf6a88320b67c7cd705ada93c