### PR TITLE
Rename historical IIP file and export additional sheets

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -66,7 +66,10 @@ class meti:
         This method retrieves three datasets related to the index of
         industrial production and saves them with Japanese filenames.
         For the dataset titled "生産・出荷・在庫・在庫率指数", the sheet named
-        "生産" is additionally exported as a CSV file.
+        "生産" is additionally exported as a CSV file. For the dataset titled
+        "過去の生産・出荷・在庫・在庫率指数（接続指数），鉱工業総合のみ"
+        "（暦年・年度・四半期）（1953年～）", the sheets "四半期（季調）" and
+        "年度（原）" are also exported as CSV files.
 
         Parameters
         ----------
@@ -105,7 +108,16 @@ class meti:
         file_paths: list[str] = []
         headers = {"User-Agent": "Mozilla/5.0"}
         for name, url in sources.items():
-            sanitized_name = name.replace("・", "_")
+            if (
+                name
+                == "過去の生産・出荷・在庫・在庫率指数（接続指数），鉱工業総合のみ（暦年・年度・四半期）（1953年～）"
+            ):
+                sanitized_name = (
+                    "過去の生産_出荷_在庫_在庫率指数_接続指数_"
+                    "鉱工業総合のみ_暦年_年度_四半期_1953年"
+                )
+            else:
+                sanitized_name = name.replace("・", "_")
             file_path = directory / f"{sanitized_name}_{date}.xlsx"
             try:
                 response = session.get(url, headers=headers, timeout=10)
@@ -123,8 +135,31 @@ class meti:
                     with csv_path.open("w", newline="", encoding="utf-8") as csvfile:
                         writer = csv.writer(csvfile)
                         for row in ws.iter_rows(values_only=True):
-                            writer.writerow([cell if cell is not None else "" for cell in row])
+                            writer.writerow(
+                                [cell if cell is not None else "" for cell in row]
+                            )
                     file_paths.append(str(csv_path))
+                wb.close()
+            elif (
+                name
+                == "過去の生産・出荷・在庫・在庫率指数（接続指数），鉱工業総合のみ（暦年・年度・四半期）（1953年～）"
+            ):
+                wb = load_workbook(file_path, data_only=True, read_only=True)
+                sheet_map = {
+                    "四半期（季調）": "四半期_季調",
+                    "年度（原）": "年度_原",
+                }
+                for sheet, suffix in sheet_map.items():
+                    if sheet in wb.sheetnames:
+                        ws = wb[sheet]
+                        csv_path = directory / f"{sanitized_name}_{suffix}_{date}.csv"
+                        with csv_path.open("w", newline="", encoding="utf-8") as csvfile:
+                            writer = csv.writer(csvfile)
+                            for row in ws.iter_rows(values_only=True):
+                                writer.writerow(
+                                    [cell if cell is not None else "" for cell in row]
+                                )
+                        file_paths.append(str(csv_path))
                 wb.close()
 
         return file_paths


### PR DESCRIPTION
## Summary
- rename historical industrial production dataset to use underscore-separated filename
- export `四半期（季調）` and `年度（原）` sheets as CSV files

## Testing
- `python -m py_compile meti_scraper.py`
- `python meti_scraper.py` *(fails: HTTPSConnectionPool(host='www.meti.go.jp', port=443): Max retries exceeded with url: ... ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688e7e5519348320a7c6a048be821db6