### PR TITLE
Add script to download METI industrial production index

### DIFF
--- a/run_meti_iip.py
+++ b/run_meti_iip.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+import sys
+
+from meti_scraper import meti
+
+
+if __name__ == "__main__":
+    today = datetime.today()
+
+    scraper = meti()
+    try:
+        iip_paths = scraper.index_of_industrial_production(date=today.strftime("%Y%m"))
+        for path in iip_paths:
+            print(path)
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add `run_meti_iip.py` for downloading industrial production index files

## Testing
- `pip install -r requirements.txt`
- `python run_meti_iip.py` (fails: Failed to download 過去の製造工業生産能力・稼働率指数（接続指数）)


------
https://chatgpt.com/codex/tasks/task_e_688e88b622208320ac5a1456c41aff57