### PR TITLE
feat: add tertiary industry index scraper

### DIFF
--- a/run_meti_ita.py
+++ b/run_meti_ita.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+import sys
+
+from meti_scraper import meti
+
+
+if __name__ == "__main__":
+    today = datetime.today()
+
+    scraper = meti()
+    try:
+        ita_paths = scraper.index_of_tertiary_industry_activity(date=today.strftime("%Y%m"))
+        for path in ita_paths:
+            print(path)
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add scraper for Index of Tertiary Industry Activity with CSV exports
- include runnable helper script for new tertiary industry index downloader

## Testing
- `python -m py_compile meti_scraper.py run_meti_ita.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8cc4bb78832094c88492138b8742