### PR TITLE
Add entry point for ESRI GDP scraper

### DIFF
--- a/esri_scraper.py
+++ b/esri_scraper.py
@@ -88,3 +88,18 @@ class esri:
                 results.append(str(file_path))
 
         return results
+
+if __name__ == "__main__":
+    from datetime import datetime
+    import sys
+
+    today = datetime.today()
+
+    scraper = esri()
+    try:
+        gdp_paths = scraper.gdp(date=today.strftime("%Y%m"))
+        for path in gdp_paths:
+            print(path)
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- allow running `esri_scraper.py` directly to download GDP CSVs for the current month

## Testing
- `python -m py_compile esri_scraper.py`
- `python esri_scraper.py` *(fails: Failed to download ESRI GDP page)*

------
https://chatgpt.com/codex/tasks/task_e_688ecd1e1b648320aea79f157e93a9ff