### PR TITLE
Fix ESRI GDP scraper URL and add Playwright fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pdfplumber
 pytesseract
 openpyxl
 beautifulsoup4
+playwright


### PR DESCRIPTION
## Summary
- update ESRI GDP scraper to point at the menu page instead of the obsolete index
- fall back to Playwright when direct requests fail
- add Playwright as a dependency

## Testing
- `pip install -r requirements.txt`
- `playwright install chromium` *(fails: domain forbidden)*
- `python -m py_compile esri_scraper.py`
- `python esri_scraper.py` *(fails: domain forbidden while downloading browser)*

------
https://chatgpt.com/codex/tasks/task_e_688ecf5a53408320ab0373b379020cc7