### PR TITLE
Convert ESRI GDP CSVs to UTF-8

### DIFF
--- a/esri_scraper.py
+++ b/esri_scraper.py
@@ -89,7 +89,18 @@ class esri:
                     ) from err
 
                 file_path = directory / f"{section}_{label}_{date}.csv"
-                file_path.write_bytes(csv_response.content)
+
+                # The CSV files provided by ESRI are encoded in Shift JIS.
+                # Convert the content to UTF-8 so that downstream consumers
+                # can read them without handling encoding details.
+                try:
+                    csv_text = csv_response.content.decode("shift_jis")
+                except UnicodeDecodeError as err:
+                    raise RuntimeError(
+                        f"Failed to decode CSV from {csv_url}: {err}"
+                    ) from err
+
+                file_path.write_text(csv_text, encoding="utf-8")
                 results.append(str(file_path))
 
         return results


### PR DESCRIPTION
## Summary
- decode Shift JIS to UTF-8 when saving ESRI GDP CSV downloads

## Testing
- `pip install -r requirements.txt`
- `python esri_scraper.py` *(fails: HTTPSConnectionPool(host='www.esri.cao.go.jp', port=443): Max retries exceeded with url: /jp/sna/menu.html (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*


------
https://chatgpt.com/codex/tasks/task_e_688ed10afd848320aa1ef7b5649fe9eb