### PR TITLE
Remove blank lines from GDP CSV downloads

### DIFF
--- a/esri_scraper.py
+++ b/esri_scraper.py
@@ -100,7 +100,12 @@ class esri:
                         f"Failed to decode CSV from {csv_url}: {err}"
                     ) from err
 
-                file_path.write_text(csv_text, encoding="utf-8")
+                # Remove empty lines so that downstream consumers do not
+                # have to handle blank rows in the CSV output.
+                cleaned_lines = [line for line in csv_text.splitlines() if line.strip()]
+                cleaned_text = "\n".join(cleaned_lines) + "\n"
+
+                file_path.write_text(cleaned_text, encoding="utf-8")
                 results.append(str(file_path))
 
         return results


### PR DESCRIPTION
## Summary
- strip blank lines from ESRI GDP CSVs before writing

## Testing
- `python -m py_compile esri_scraper.py`
- `python esri_scraper.py` *(fails: Failed to download ESRI GDP page: HTTPSConnectionPool(host='www.esri.cao.go.jp', port=443): Max retries exceeded with url: /jp/sna/menu.html (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_688ed265f934832090a2acc10bac87d3