### PR TITLE
Handle missing kp23 PDF/Excel links

### DIFF
--- a/esri_scraper.py
+++ b/esri_scraper.py
@@ -162,12 +162,19 @@ class esri:
             ) from err
 
         soup = BeautifulSoup(response.content, "html.parser")
-        ul = soup.find("ul", class_="bulletList")
-        if not ul:
+
+        pdf_link = None
+        xls_link = None
+        lists = soup.find_all("ul", class_="bulletList")
+        if not lists:
             raise RuntimeError("Failed to locate kp23 links on ESRI page")
 
-        pdf_link = ul.find("a", href=lambda h: h and h.endswith(".pdf"))
-        xls_link = ul.find("a", href=lambda h: h and h.endswith((".xls", ".xlsx")))
+        for ul in lists:
+            pdf_link = ul.find("a", href=lambda h: h and h.endswith(".pdf"))
+            xls_link = ul.find("a", href=lambda h: h and h.endswith((".xls", ".xlsx")))
+            if pdf_link and xls_link:
+                break
+
         if not pdf_link or not xls_link:
             raise RuntimeError("Missing PDF or Excel link on kp23 page")
 


### PR DESCRIPTION
## Summary
- Search all `bulletList` sections on the kp23 page to locate both PDF and Excel files

## Testing
- `python -m py_compile esri_scraper.py`
- `python esri_scraper.kp23(date="201501")` *(fails: Failed to download ESRI kp23 page: HTTPSConnectionPool(host='www.esri.cao.go.jp', port=443): Max retries exceeded with url: /jp/sna/sonota/kotei/kotei_top.html (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_688edbae0e888320941b0a95ff903242