### PR TITLE
Remove blank rows from kp23 CSV exports

### DIFF
--- a/esri_scraper.py
+++ b/esri_scraper.py
@@ -229,6 +229,10 @@ class esri:
             with csv_path.open("w", newline="", encoding="utf-8") as csvfile:
                 writer = csv.writer(csvfile)
                 for row in ws.iter_rows(values_only=True):
+                    if not any(
+                        cell is not None and str(cell).strip() for cell in row
+                    ):
+                        continue
                     writer.writerow([cell if cell is not None else "" for cell in row])
             results.append(str(csv_path))
         wb.close()

--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -313,6 +313,11 @@ class meti:
         with csv_path.open("w", newline="", encoding="utf-8") as csvfile:
             writer = csv.writer(csvfile)
             for row in table:
+                # Skip completely empty rows to avoid blank lines in the output
+                if not any(
+                    cell is not None and str(cell).strip() for cell in row
+                ):
+                    continue
                 writer.writerow([cell or "" for cell in row])
 
     def pdf_tables_to_csv(self, pdf_path: str) -> list[str]:


### PR DESCRIPTION
## Summary
- filter out completely empty rows when saving kp23 PDF tables to CSV
- drop blank lines when exporting kp23 Excel sheets to CSV

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edd134eac8320a7936d3e92efc6fb