### PR TITLE
Skip blank rows when exporting Jutaku CSV

### DIFF
--- a/mlit_scraper.py
+++ b/mlit_scraper.py
@@ -87,7 +87,9 @@ class mlit:
         with csv_path.open("w", newline="", encoding="utf-8") as csvfile:
             writer = csv.writer(csvfile)
             for row_idx in range(sheet.nrows):
-                writer.writerow(sheet.row_values(row_idx))
+                row = sheet.row_values(row_idx)
+                if any(str(cell).strip() for cell in row):
+                    writer.writerow(row)
 
         return [str(xls_path), str(csv_path)]
 


### PR DESCRIPTION
## Summary
- skip empty rows when writing MLIT 'jyuu' sheet to Jutaku CSV export

## Testing
- `python mlit_scraper.py` *(fails: Failed to fetch MLIT landing page)*
- `python -m py_compile mlit_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_688ee89cc598832095ebc22c421407cd