### PR TITLE
Add Soumu communications survey scraper

### DIFF
--- a/soumu_scraper.py
+++ b/soumu_scraper.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from urllib.parse import urljoin
+from datetime import datetime
+
+import hashlib
+import sys
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from bs4 import BeautifulSoup
+
+
+class soumu:
+    """Downloader for MIC Communications Usage Trend Survey PDFs."""
+
+    _URL = "https://www.soumu.go.jp/johotsusintokei/field/tsuushin/02kekka.html"
+
+    def it_survey(self, date: str) -> list[str]:
+        """Download Communications Usage Trend Survey PDFs.
+
+        Parameters
+        ----------
+        date: str
+            Date string in YYYYMM format appended to each filename.
+
+        Returns
+        -------
+        list[str]
+            Paths to the newly downloaded PDF files.
+        """
+
+        directory = Path("pdf") / "it"
+        directory.mkdir(parents=True, exist_ok=True)
+
+        # Compute hashes of existing PDFs to avoid duplicates.
+        existing_hashes: set[str] = set()
+        for pdf_file in directory.glob("*.pdf"):
+            hasher = hashlib.sha256()
+            hasher.update(pdf_file.read_bytes())
+            existing_hashes.add(hasher.hexdigest())
+
+        session = requests.Session()
+        retry = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+
+        try:
+            response = session.get(
+                self._URL,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=10,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            raise RuntimeError("Failed to fetch Soumu IT survey page") from err
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        links = soup.find_all("a", href=lambda h: h and h.endswith(".pdf"))
+
+        downloaded: list[str] = []
+        for link in links:
+            pdf_url = urljoin(self._URL, link["href"])
+            try:
+                pdf_resp = session.get(
+                    pdf_url,
+                    headers={"User-Agent": "Mozilla/5.0"},
+                    timeout=10,
+                )
+                pdf_resp.raise_for_status()
+            except requests.exceptions.RequestException as err:
+                raise RuntimeError(
+                    f"Failed to download PDF from {pdf_url}") from err
+
+            file_hash = hashlib.sha256(pdf_resp.content).hexdigest()
+            if file_hash in existing_hashes:
+                continue
+
+            original_name = Path(link["href"]).name
+            file_path = directory / f"{Path(original_name).stem}_{date}{Path(original_name).suffix}"
+            file_path.write_bytes(pdf_resp.content)
+            existing_hashes.add(file_hash)
+            downloaded.append(str(file_path))
+
+        return downloaded
+
+
+if __name__ == "__main__":
+    today = datetime.today()
+    scraper = soumu()
+    try:
+        paths = scraper.it_survey(date=today.strftime("%Y%m"))
+        for p in paths:
+            print(p)
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add scraper for MIC Communications Usage Trend Survey PDFs
- skip downloading existing files by hashing current PDF contents

## Testing
- `python -m py_compile soumu_scraper.py`
- `python soumu_scraper.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688eecd959a083208946098143e8d679