### PR TITLE
Add script to run MOF customs scraper

### DIFF
--- a/run_mof_customs.py
+++ b/run_mof_customs.py
@@ -1,0 +1,11 @@
+from mof_scraper import mof
+import sys
+
+
+if __name__ == "__main__":
+    scraper = mof()
+    try:
+        scraper.customs()
+    except RuntimeError as err:
+        print(err)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add `run_mof_customs.py` script to execute the MOF customs CSV downloader

## Testing
- `python run_mof_customs.py` *(fails: Failed to download CSV from https://www.customs.go.jp/toukei/suii/html/data/d61ma.csv)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6e84aebc8320b89c8bbe6cc3f5be