### PR TITLE
Add main block for Japan NRG weekly scraper

### DIFF
--- a/report_scraper.py
+++ b/report_scraper.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
+import sys
 
 import requests
 
@@ -105,4 +106,37 @@ class nrg:
             Path("pdf") / "nrg" / "weekly",
             f"Japan_NRG_Weekly_{date_str}.pdf",
         )
+
+
+if __name__ == "__main__":
+    today = datetime.today()
+    weekday = today.weekday()  # Monday = 0, Sunday = 6
+    if weekday == 0:
+        monday = today - timedelta(days=7)
+    else:
+        monday = today - timedelta(days=weekday)
+
+    scraper = nrg()
+
+    if len(sys.argv) == 3:
+        start = datetime.strptime(sys.argv[1], "%Y%m%d")
+        end = datetime.strptime(sys.argv[2], "%Y%m%d")
+        print(
+            f"Downloading Japan NRG Weekly from {start:%Y-%m-%d} to {end:%Y-%m-%d}"
+        )
+        current = start
+        while current <= end:
+            try:
+                path = scraper.nrg_japan_weekly(date=current)
+                print(path)
+            except RuntimeError as err:
+                print(err)
+            current += timedelta(days=7)
+    else:
+        try:
+            path = scraper.nrg_japan_weekly(date=monday)
+            print(path)
+        except RuntimeError as err:
+            print(err)
+            sys.exit(1)
 


### PR DESCRIPTION
## Summary
- allow running Japan NRG weekly PDF download directly
- support looping over weekly downloads between two Mondays

## Testing
- `python -m py_compile report_scraper.py`
- `python report_scraper.py` *(fails: ProxyError 403)*
- `python report_scraper.py 20240701 20240715` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_688f73c61b708320925243fe45009eb4