### PR TITLE
Handle missing weekly NRG PDF by checking next day

### DIFF
--- a/report_scraper.py
+++ b/report_scraper.py
@@ -88,18 +88,23 @@ class nrg:
             Path to the downloaded PDF file.
         """
         date = date or datetime.now()
-        year = date.year
-        month = date.month
-        day = date.day
-        date_str = date.strftime("%Y%m%d")
 
-        url = (
-            f"{self._BASE_URL}/{year}/{month:02d}/"
-            f"Japan-NRG-Weekly-{year}{month:02d}{day:02d}.pdf"
-        )
+        def build_url(d: datetime) -> str:
+            return (
+                f"{self._BASE_URL}/{d.year}/{d.month:02d}/"
+                f"Japan-NRG-Weekly-{d.year}{d.month:02d}{d.day:02d}.pdf"
+            )
+
+        url_date = date
+        url = build_url(url_date)
 
         if requests.head(url).status_code != 200:
-            raise RuntimeError("Failed to locate Japan NRG Weekly PDF")
+            url_date = date + timedelta(days=1)
+            url = build_url(url_date)
+            if requests.head(url).status_code != 200:
+                raise RuntimeError("Failed to locate Japan NRG Weekly PDF")
+
+        date_str = url_date.strftime("%Y%m%d")
 
         return self._download(
             url,


### PR DESCRIPTION
## Summary
- try downloading Japan NRG Weekly report using the next day's date if the first attempt fails

## Testing
- `python -m py_compile report_scraper.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f7846ad348320adbf75c75a1f98fb