### PR TITLE
Add markdown conversion for NRG weekly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytesseract
 openpyxl
 beautifulsoup4
 xlrd
+googletrans==4.0.0-rc1

--- a/run_report_nrg_weekly.py
+++ b/run_report_nrg_weekly.py
@@ -23,15 +23,17 @@ if __name__ == "__main__":
         current = start
         while current <= end:
             try:
-                path = scraper.nrg_japan_weekly(date=current)
-                print(path)
+                paths = scraper.nrg_japan_weekly(date=current)
+                for p in paths:
+                    print(p)
             except RuntimeError as err:
                 print(err)
             current += timedelta(days=7)
     else:
         try:
-            path = scraper.nrg_japan_weekly(date=monday)
-            print(path)
+            paths = scraper.nrg_japan_weekly(date=monday)
+            for p in paths:
+                print(p)
         except RuntimeError as err:
             print(err)
             sys.exit(1)


### PR DESCRIPTION
## Summary
- Convert Japan NRG Weekly PDF to Markdown and generate English and Chinese versions without exporting images
- Extend PDF conversion helper to optionally skip image extraction
- Update runner to handle new Markdown outputs

## Testing
- `python -m py_compile meti_scraper.py report_scraper.py run_report_nrg_weekly.py`
- `pip install -r requirements.txt`
- `python run_report_nrg_weekly.py 20240101 20240101` *(fails: `ProxyError`)*

------
https://chatgpt.com/codex/tasks/task_e_688f7de32c0c832085bcfa9150698687