### PR TITLE
Handle SSL verification failure for METI LNG stock download

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -6,6 +6,7 @@ from openpyxl import load_workbook
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+import urllib3
 import pdfplumber
 import pytesseract
 
@@ -36,6 +37,7 @@ class meti:
         file_path = directory / f"denryoku_LNG_stock_{date}.pdf"
 
         session = requests.Session()
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         retry = Retry(
             total=5,
             backoff_factor=1,
@@ -51,6 +53,7 @@ class meti:
                 self._URL,
                 headers={"User-Agent": "Mozilla/5.0"},
                 timeout=10,
+                verify=False,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as err:


### PR DESCRIPTION
## Summary
- disable SSL verification and warnings when fetching METI LNG stock PDF to avoid certificate errors

## Testing
- `python run_meti_lng_weekly_inventory.py` *(fails: Failed to download METI LNG stock PDF)*

------
https://chatgpt.com/codex/tasks/task_e_6892e226a3cc832095146abbaedea0c1