### PR TITLE
Improve error handling for LNG inventory download

### DIFF
--- a/meti_scraper.py
+++ b/meti_scraper.py
@@ -57,7 +57,10 @@ class meti:
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as err:
-            raise RuntimeError("Failed to download METI LNG stock PDF") from err
+            raise RuntimeError(
+                f"Failed to download METI LNG stock PDF: {err}. "
+                "This may be due to network restrictions or the resource being unavailable."
+            ) from err
 
         file_path.write_bytes(response.content)
         print(file_path)

--- a/run_meti_lng_weekly_inventory.py
+++ b/run_meti_lng_weekly_inventory.py
@@ -25,5 +25,9 @@ if __name__ == "__main__":
             print(path)
     except RuntimeError as err:
         print(err)
+        print("Check network connection or if the METI site is reachable.")
+        sys.exit(1)
+    except Exception as err:
+        print(f"Unexpected error: {err}")
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- clarify network-related failures when downloading METI LNG stock PDF
- surface helpful messages in the CLI runner on errors

## Testing
- `python run_meti_lng_weekly_inventory.py >/tmp/run.log && tail -n 20 /tmp/run.log` *(fails: Unable to connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6892e596dc9c8320bb5800c721f81e69